### PR TITLE
Fix `num_threads` argument not used consistently in `train` of  `BasicSearchAlgorithm`

### DIFF
--- a/opto/trainer/algorithms/algorithm.py
+++ b/opto/trainer/algorithms/algorithm.py
@@ -1,4 +1,6 @@
 import warnings
+from typing import Optional
+
 from opto import trace
 from opto.trace.modules import Module
 from opto.trainer.utils import async_run
@@ -28,7 +30,7 @@ class AlgorithmBase(AbstractAlgorithm):
 
     def __init__(self,
                  agent,  # trace.model
-                 num_threads: int = None,   # maximum number of threads to use for parallel execution
+                 num_threads: Optional[int] = None,   # maximum number of threads to use for parallel execution
                  logger=None,  # logger for tracking metrics
                  *args,
                  **kwargs):

--- a/opto/trainer/algorithms/basic_algorithms.py
+++ b/opto/trainer/algorithms/basic_algorithms.py
@@ -145,7 +145,7 @@ class Minibatch(AlgorithmBase):
                     outputs = [self.forward(self.agent, x, guide, info) for x, info in zip(xs, infos) ]
 
                 # Update the agent
-                score = self.update(outputs, verbose=verbose)
+                score = self.update(outputs, verbose=verbose, num_threads=num_threads, **kwargs)
 
                 # Reject the update if the score on the current batch is not improved
                 if ensure_improvement:
@@ -225,14 +225,16 @@ class Minibatch(AlgorithmBase):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def update(self, outputs, verbose=False):
+    def update(self, outputs, verbose=False, num_threads=None, **kwargs):
         """ Subclasses can implement this method to update the agent.
             Args:
                 outputs: returned value from self.step
                 verbose: whether to print the output of the agent
+                num_threads: maximum number of threads to use (overrides self.num_threads)
             Returns:
                 score: average score of the minibatch of inputs
         """
+        num_threads = num_threads or self.num_threads  # Use provided num_threads or fall back to self.num_threads
         raise NotImplementedError("Subclasses must implement this method")
 
 
@@ -254,15 +256,18 @@ class MinibatchAlgorithm(Minibatch):
     def forward(self, agent, x, guide, info):
         return standard_optimization_step(agent, x, guide, info)  # (score, target, feedback)
 
-    def update(self, outputs, *args, **kwargs):
+    def update(self, outputs, verbose=False, num_threads=None, **kwargs):
         """ Subclasses can implement this method to update the agent.
             Args:
                 outputs: returned value from self.step
                 verbose: whether to print the output of the agent
+                num_threads: maximum number of threads to use (overrides self.num_threads)
             Returns:
                 score: average score of the minibatch of inputs
 
         """
+        num_threads = num_threads or self.num_threads  # Use provided num_threads or fall back to self.num_threads
+
         scores, targets, feedbacks = [], [], []
         # Concatenate the targets and feedbacks into a single string
         for target, score, feedback in outputs:
@@ -276,14 +281,14 @@ class MinibatchAlgorithm(Minibatch):
         # Update the agent using the feedback
         self.optimizer.zero_feedback()
         self.optimizer.backward(target, feedback)
-        self.optimizer_step(*args, **kwargs)  # update the agent
+        self.optimizer_step(verbose=verbose, num_threads=num_threads, **kwargs)  # update the agent
 
         return average_score  # return the average score of the minibatch of inputs
 
-    def optimizer_step(self, bypassing=False, *args, **kwargs):
+    def optimizer_step(self, bypassing=False, verbose=False, num_threads=None, **kwargs):
         """ Subclasses can implement this method to update the agent. """
         # We separate this method from the update method to allow subclasses to implement their own optimization step.
-        return self.optimizer.step(*args, bypassing=bypassing, **kwargs)
+        return self.optimizer.step(bypassing=bypassing, verbose=verbose, **kwargs)
 
 
 class BasicSearchAlgorithm(MinibatchAlgorithm):
@@ -318,8 +323,10 @@ class BasicSearchAlgorithm(MinibatchAlgorithm):
                       min_score=min_score, verbose=verbose, num_threads=num_threads, **kwargs)
 
     # This code should be reusable for other algorithms
-    def optimizer_step(self, bypassing=False, verbose=False, *args, **kwargs):
+    def optimizer_step(self, bypassing=False, verbose=False, num_threads=None, **kwargs):
         """ Use the optimizer to propose multiple updates and select the best one based on validation score. """
+
+        num_threads = num_threads or self.num_threads  # Use provided num_threads or fall back to self.num_threads
 
         def validate():
             """ Validate the agent on the validation dataset. """
@@ -328,18 +335,19 @@ class BasicSearchAlgorithm(MinibatchAlgorithm):
                               self.validate_dataset['inputs'],
                               self.validate_dataset['infos'],
                               min_score=self.min_score,
-                              num_threads=self.num_threads,
+                              num_threads=num_threads,
                               description="Validating proposals")
             return np.mean(scores) if all([s is not None for s in scores]) else -np.inf
 
         # TODO perhaps we can ask for multiple updates in one query or use different temperatures in different queries
         # Generate different proposals
         step_kwargs = dict(bypassing=True, verbose='output')  # we don't print the inner full message
+        step_kwargs.update(kwargs)  # update with additional kwargs if provided
         use_asyncio = self._use_asyncio()
         if use_asyncio:
             update_dicts = async_run([super().optimizer_step]*self.num_proposals,
                                     kwargs_list=[step_kwargs] * self.num_proposals,
-                                    max_workers=self.num_threads,
+                                    max_workers=num_threads,
                                     description=f"Generating {self.num_proposals} proposals")  # async step
         else:
             update_dicts = [self.optimizer.step(**step_kwargs) for _ in range(self.num_proposals)]

--- a/tests/unit_tests/test_modules.py
+++ b/tests/unit_tests/test_modules.py
@@ -239,7 +239,7 @@ def test_model_dump_with_projection():
     try:
         # Test with BlackCodeFormatter
         from opto.trace.projections import BlackCodeFormatter
-        dummy.model_dump(temp_file, projection=BlackCodeFormatter())
+        dummy.model_dump(temp_file, projections=[BlackCodeFormatter()])
         with open(temp_file, "r") as f:
             content = f.read()
             # Check if content is properly formatted


### PR DESCRIPTION
This issue is due to the API inconsistency of `update` in `Minibatch` class.