### PR TITLE
Feature/improved evaluate

### DIFF
--- a/examples/gsm8k_trainer_example.py
+++ b/examples/gsm8k_trainer_example.py
@@ -71,7 +71,7 @@ def main():
     test_dataset = train_dataset
 
     agent = Learner(llm=LLM(student_model))
-    guide = Guide(model=LLM(teacher_model))
+    guide = Guide(llm=LLM(teacher_model))
     optimizer = OptoPrime(agent.parameters(), llm=LLM(optimizer_model))
     logger = Logger(verbose=verbose)
              # set use_json_object_format=False if LLM does not support JSON object format

--- a/opto/trace/modules.py
+++ b/opto/trace/modules.py
@@ -107,6 +107,15 @@ class Module(ParameterContainer):
 
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
+        
+    def copy(self):
+        """Return a deep copy of the module except for the parameters 
+        are set to the originals."""
+        new_module = copy.deepcopy(self)
+        for k, v in self.parameters_dict().items():
+            if hasattr(new_module, k):
+                setattr(new_module, k, v)
+        return new_module
 
     def save(self, file_name: str):
         """Save the parameters of the model to a pickle file."""

--- a/opto/trace/modules.py
+++ b/opto/trace/modules.py
@@ -16,6 +16,7 @@ def model(cls):
     """
 
     class ModelWrapper(cls, Module):
+
         def model_dump(self, filename, projections: Optional[List[Projection]] = None):
             """Dump the model's source code to a file, including all methods and attributes.
             Ignores dunder methods unless they were overridden by the user.
@@ -24,7 +25,7 @@ def model(cls):
                 projections = [BlackCodeFormatter()]
 
             trace_model_body = f"class {cls.__name__}:\n"
-            
+
             # Get all members of the class
             all_members = inspect.getmembers(self)
             cls_members = inspect.getmembers(cls)
@@ -39,7 +40,7 @@ def model(cls):
 
                 if name not in cls_member_names:
                     continue
-                    
+
                 # Include if it's not a dunder method or if it was overridden
                 if not name.startswith('__'):
                     filtered_members.append((name, member))
@@ -72,7 +73,7 @@ def model(cls):
                     source = textwrap.dedent(source)
                     indented = textwrap.indent(source, "    ")
                     trace_model_body += indented
-                
+
                 if i < len(all_members) - 1:
                     trace_model_body += "\n"  # only one newline between members
 
@@ -80,7 +81,7 @@ def model(cls):
             # WARNING: there might be corner cases that this static analysis does not cover
             import re
             node_pattern = r'self\.(\w+)\s*=\s*node\([^)]*\)'
-            
+
             def replace_node(match):
                 attr_name = match.group(1)
                 if hasattr(self, attr_name):
@@ -88,7 +89,7 @@ def model(cls):
                     if hasattr(attr, 'data'):
                         return f"self.{attr_name} = {attr.data}"
                 return match.group(0)  # Return original if replacement not possible
-            
+
             trace_model_body = re.sub(node_pattern, replace_node, trace_model_body)
 
             trace_model_body = functools.reduce(lambda body, proj: proj.project(body), projections, trace_model_body)
@@ -107,15 +108,6 @@ class Module(ParameterContainer):
 
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
-        
-    def copy(self):
-        """Return a deep copy of the module except for the parameters 
-        are set to the originals."""
-        new_module = copy.deepcopy(self)
-        for k, v in self.parameters_dict().items():
-            if hasattr(new_module, k):
-                setattr(new_module, k, v)
-        return new_module
 
     def save(self, file_name: str):
         """Save the parameters of the model to a pickle file."""

--- a/opto/trainer/algorithms/__init__.py
+++ b/opto/trainer/algorithms/__init__.py
@@ -1,1 +1,3 @@
 from opto.trainer.algorithms.basic_algorithms import Minibatch, MinibatchAlgorithm, BasicSearchAlgorithm
+from opto.trainer.algorithms.beamsearch_algorithm import BeamsearchAlgorithm, BeamsearchHistoryAlgorithm
+from opto.trainer.algorithms.UCBsearch import UCBSearchAlgorithm

--- a/opto/trainer/algorithms/algorithm.py
+++ b/opto/trainer/algorithms/algorithm.py
@@ -1,9 +1,5 @@
-import warnings
 from typing import Optional
-
-from opto import trace
 from opto.trace.modules import Module
-from opto.trainer.utils import async_run
 from opto.trainer.loggers import DefaultLogger
 import os
 

--- a/opto/trainer/evaluators.py
+++ b/opto/trainer/evaluators.py
@@ -1,6 +1,7 @@
-from opto.trainer.utils import async_run, batch_run
+from opto.trainer.utils import batch_run
 from opto.trace import ExecutionError
 import copy
+import numpy as np
 
 
 def evaluate(agent, guide, inputs, infos, min_score=None, num_samples=1, num_threads=None, description=None):
@@ -35,5 +36,9 @@ def evaluate(agent, guide, inputs, infos, min_score=None, num_samples=1, num_thr
 
     # Run the evaluation in parallel
     scores = _evaluate(agent, guide, indices)
-
+    scores = np.array(scores)
+    if num_samples > 1:
+        # scores will be of length N * num_samples
+        # Reshape scores into an array of shape (N, num_samples)        
+        scores = scores.reshape(N, num_samples)
     return scores

--- a/opto/trainer/evaluators.py
+++ b/opto/trainer/evaluators.py
@@ -1,0 +1,42 @@
+from opto.trainer.utils import async_run
+import copy
+
+
+def evaluate(agent, guide, inputs, infos, min_score=None, num_samples=1, num_threads=None, description=None):
+    """ Evaluate the agent on the inputs and return the scores
+
+    Args:
+        agent: The agent to evaluate
+        guide: The guide to use for evaluation
+        inputs: List of inputs to evaluate on
+        infos: List of additional information for each input
+        min_score: Minimum score to return when an exception occurs
+        num_samples: Number of samples to use to evaluate each input
+        num_threads: Maximum number of threads to use for parallel evaluation
+        description: Description to display in the progress bar
+    """
+
+    def evaluate_single(agent, guide, i):
+        try:
+            output = agent(inputs[i]).data
+            score = guide.metric(inputs[i], output, infos[i])
+        except:
+            score = min_score
+        return score
+
+    N = len(inputs)
+    assert len(inputs) == len(infos), "Inputs and infos must have the same length"
+    # Use asyncio if num_threads is not None and > 1
+    use_asyncio = num_threads is not None and num_threads > 1
+
+    # repeat each index num_samples times
+    indices = [i for i in range(N) for _ in range(num_samples)]
+    if use_asyncio:
+        # Use provided description or generate a default one
+        eval_description = description or f"Evaluating {N} examples"
+        scores = async_run([evaluate_single] * N, [(copy.deepcopy(agent), copy.deepcopy(guide), i) for i in indices],
+                          max_workers=num_threads,
+                          description=eval_description) # list of tuples
+    else:
+        scores = [evaluate_single(agent, guide, i) for i in indices]
+    return scores

--- a/opto/trainer/guide.py
+++ b/opto/trainer/guide.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Any, Union, Tuple, Optional, Callable
 import json
 import re
+import copy
 from opto.utils.llm import LLM, AbstractModel
 from opto.trainer.suggest import Suggest
 
@@ -43,6 +44,16 @@ class AutoGuide:
     def metric(self, query: str, response: str, reference: Optional[str] = None, **kwargs) -> float:
         """ Exact match metric """
         return self.get_feedback(query, response, reference)[0]
+    
+    def copy(): 
+        """ Create a copy of the guide instance.
+
+        Returns:
+            A new instance of the same guide class with the same parameters.
+        """
+        # This is used in batch_run to create a new instance of the guide.
+        # This can be overridden by subclasses to provide a more specific copy behavior.
+        return copy.deepcopy(self)
 
 
 class VerbalJudgeGuide(AutoGuide):

--- a/opto/trainer/utils.py
+++ b/opto/trainer/utils.py
@@ -34,6 +34,7 @@ def async_run(runs, args_list = None, kwargs_list = None, max_workers = None, de
         kwargs_list = [{}] * len(runs)
 
     if (max_workers == 1) and allow_sequential_run: # run without asyncio
+        print(f"{description} (Running sequentially).")
         return [run(*args, **kwargs) for run, args, kwargs in zip(runs, args_list, kwargs_list)]
     else: 
         async def _run():

--- a/opto/trainer/utils.py
+++ b/opto/trainer/utils.py
@@ -4,6 +4,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from tqdm.asyncio import tqdm_asyncio
 from opto.trace.bundle import ALLOW_EXTERNAL_DEPENDENCIES
+from opto.trace.modules import Module
 
 def async_run(runs, args_list = None, kwargs_list = None, max_workers = None, description = None):
     """Run multiple functions in asynchronously.
@@ -45,6 +46,74 @@ def async_run(runs, args_list = None, kwargs_list = None, max_workers = None, de
                 return await tqdm_asyncio.gather(*tasks)
 
     return asyncio.run(_run())
+
+
+def batch_run(fun, max_workers=None, description=None):
+    """
+    Create a function that runs in parallel using asyncio, with support for batching.
+    The batch size is inferred as the length of the longest argument or keyword argument.            
+
+    Args:
+        fun (callable): The function to run.
+        
+        max_workers (int, optional): Maximum number of worker threads to use.
+            If None, the default ThreadPoolExecutor behavior is used.
+        description (str, optional): Description to display in the progress bar.
+
+    Returns:
+        callable: A new function that processes batches of inputs.
+
+    NOTE: 
+        If fun takes input that has __len__ (like lists or arrays), they won't be broadcasted. 
+        When using batch_run, be sure to pass list of such arguments of the same length.       
+
+    Example:
+        >>> @batch_run(max_workers=4, description="Processing batch")
+        >>> def my_function(x, y):
+        >>>     return x + y
+        >>>     x = [1, 2, 3, 4, 5]
+        >>>     y = 10
+        >>>     outputs = my_function(x, y)
+        >>>     # outputs will be [11, 12, 13, 14, 15]
+        >>>     # This will run the function in asynchronously with 4 threads   
+    """
+    
+    
+    def _fun(*args, **kwargs):
+        
+        # We try to infer the batch size from the args
+        all_args = args + tuple(kwargs.values())
+        # find all list or array-like arguments and use their length as batch size
+        batch_size = max(len(arg) for arg in all_args if hasattr(arg, '__len__'))
+        
+        # broadcast the batch size to all args and record the indices that are broadcasted
+        args = [arg if hasattr(arg, '__len__') else [arg] * batch_size for arg in args]
+        kwargs = {k: v if hasattr(v, '__len__') else [v] * batch_size for k, v in kwargs.items()}   
+
+        # assert that all args and kwargs have the same length
+        lengths = [len(arg) for arg in args] + [len(v) for v in kwargs.values()]
+        if len(set(lengths)) != 1:
+            raise ValueError("All arguments and keyword arguments must have the same length.")
+
+        # deepcopy if it is a trace.Module (as they may have mutable state)
+        # Module.copy() is used to create a new instance with the same parameters
+        _args = [arg.copy() if isinstance(arg, Module) else arg for arg in args]
+        _kwargs = {k: v.copy() if isinstance(v, Module) else v for k, v in kwargs.items()}
+
+        # Run the forward function in parallel using asyncio with the same parameters. 
+        # Since trace.Node is treated as immutable, we can safely use the same instance.
+        # The resultant graph will be the same as if we had called the function with the original arguments.
+
+        # convert _args and _kwargs (args, kwargs of list) to lists of args and kwargs
+
+        args_list = [tuple(aa[i] for aa in _args) for i in range(batch_size)]
+        kwargs_list = [{k: _kwargs[k][i] for k in _kwargs} for i in range(batch_size)]
+
+        outputs = async_run([fun] * batch_size, args_list=args_list, kwargs_list=kwargs_list,
+                            max_workers=max_workers, description=description)
+        return outputs
+
+    return _fun
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_batch_run.py
+++ b/tests/unit_tests/test_batch_run.py
@@ -1,0 +1,78 @@
+from typing import List
+from opto import trace
+from opto.trainer.utils import batch_run
+
+def test_batch_run_fun():
+
+    def fun(x, y):
+        return x + y
+
+    # Create a batch of inputs
+    x = [1, 2, 3, 4, 5]
+    y = 10   # this will be broadcasted to each element in x
+
+    # Run the function in batch mode
+    outputs = batch_run(fun, max_workers=3)(x,y)
+    assert outputs == [11, 12, 13, 14, 15], f"Expected [11, 12, 13, 14, 15], got {outputs}"
+
+    # Handling a function taking a list as inputs
+    def fun(x: List[int], y: List[int]) -> List[int]:
+        return [a + b for a, b in zip(x, y)]
+
+    x = [[1, 2, 3], [4, 5, 6]]
+    y = [10, 20, 30]  # list won't be braodcasted correctly 
+
+    raise_error = False
+    try: 
+        outputs = batch_run(fun, max_workers=3)(x, y)
+    except ValueError as e:
+        assert str(e) == "All arguments and keyword arguments must have the same length.", f"Unexpected error: {e}"
+        raise_error = True
+    assert raise_error, "Expected a ValueError but did not get one."
+
+    # Now we can broadcast y to match the length of x
+    y = [[10, 20, 30]] * len(x)  # Broadcast
+    outputs = batch_run(fun, max_workers=3)(x, y)
+    assert outputs == [[11, 22, 33], [14, 25, 36]], f"Expected [[11, 22, 33], [14, 25, 36]], got {outputs}"
+
+
+    y = [10, 20] # This will raise an error because x and y have different lengths
+    raise_error = False
+    try:
+        outputs = batch_run(fun, max_workers=3)(x, y)
+    except TypeError as e:
+        raise_error = True
+    assert raise_error, "Expected a TypeError but did not get one."
+
+def test_batch_run_module():
+
+
+    @trace.model
+    class MyModule:
+        def __init__(self, param):
+            self.param = trace.node(param, trainable=True)
+            self._state = 0
+        
+        def forward(self, x):
+            y =  x + self.param
+            self._state += 1  # This should not affect the batch run
+            return y
+        
+    module = MyModule(10)
+    x = [1, 2, 3, 4, 5]
+    outputs = batch_run(module.forward, max_workers=3)(x)
+    assert outputs == [11, 12, 13, 14, 15], f"Expected [11, 12, 13, 14, 15], got {outputs}"
+    param = module.parameters()[0]
+    assert len(param.children) == 5
+
+
+    x = [1, 2, 3, 4, 5]
+    y = [10, 20, 30, 40, 50, 60]
+    # This should raise an error because x and y have different lengths
+    raise_error = False
+    try: 
+        outputs = batch_run(module.forward, max_workers=3)(x, y)
+    except ValueError as e:
+        assert str(e) == "All arguments and keyword arguments must have the same length.", f"Unexpected error: {e}"
+        raise_error = True
+    assert raise_error, "Expected a ValueError but did not get one."

--- a/tests/unit_tests/test_batch_run.py
+++ b/tests/unit_tests/test_batch_run.py
@@ -4,6 +4,7 @@ from opto.trainer.utils import batch_run
 
 def test_batch_run_fun():
 
+    @batch_run(max_workers=3)
     def fun(x, y):
         return x + y
 
@@ -12,10 +13,11 @@ def test_batch_run_fun():
     y = 10   # this will be broadcasted to each element in x
 
     # Run the function in batch mode
-    outputs = batch_run(fun, max_workers=3)(x,y)
+    outputs = fun(x,y)
     assert outputs == [11, 12, 13, 14, 15], f"Expected [11, 12, 13, 14, 15], got {outputs}"
 
     # Handling a function taking a list as inputs
+    @batch_run(max_workers=3)
     def fun(x: List[int], y: List[int]) -> List[int]:
         return [a + b for a, b in zip(x, y)]
 
@@ -24,7 +26,7 @@ def test_batch_run_fun():
 
     raise_error = False
     try: 
-        outputs = batch_run(fun, max_workers=3)(x, y)
+        outputs = fun(x, y)
     except ValueError as e:
         assert str(e) == "All arguments and keyword arguments must have the same length.", f"Unexpected error: {e}"
         raise_error = True
@@ -32,14 +34,14 @@ def test_batch_run_fun():
 
     # Now we can broadcast y to match the length of x
     y = [[10, 20, 30]] * len(x)  # Broadcast
-    outputs = batch_run(fun, max_workers=3)(x, y)
+    outputs = fun(x, y)
     assert outputs == [[11, 22, 33], [14, 25, 36]], f"Expected [[11, 22, 33], [14, 25, 36]], got {outputs}"
 
 
     y = [10, 20] # This will raise an error because x and y have different lengths
     raise_error = False
     try:
-        outputs = batch_run(fun, max_workers=3)(x, y)
+        outputs = fun(x, y)
     except TypeError as e:
         raise_error = True
     assert raise_error, "Expected a TypeError but did not get one."
@@ -60,7 +62,7 @@ def test_batch_run_module():
         
     module = MyModule(10)
     x = [1, 2, 3, 4, 5]
-    outputs = batch_run(module.forward, max_workers=3)(x)
+    outputs = batch_run(max_workers=3)(module.forward)(x)
     assert outputs == [11, 12, 13, 14, 15], f"Expected [11, 12, 13, 14, 15], got {outputs}"
     param = module.parameters()[0]
     assert len(param.children) == 5
@@ -71,7 +73,7 @@ def test_batch_run_module():
     # This should raise an error because x and y have different lengths
     raise_error = False
     try: 
-        outputs = batch_run(module.forward, max_workers=3)(x, y)
+        outputs = batch_run(max_workers=3)(module.forward)(x, y)
     except ValueError as e:
         assert str(e) == "All arguments and keyword arguments must have the same length.", f"Unexpected error: {e}"
         raise_error = True

--- a/tests/unit_tests/test_batch_run.py
+++ b/tests/unit_tests/test_batch_run.py
@@ -99,7 +99,6 @@ def test_evaluate():
         def get_feedback(self, query, response, reference=None):
             score = float(response == query + self.param + reference)
             feedback = f"Score: {score}, Response: {response}, Query: {query}"            
-            print(score, feedback)
             self.param += 1  # This should not affect the batch run
             return score, feedback
     
@@ -109,4 +108,9 @@ def test_evaluate():
     infos = [0, 1, 2, 3, 4]  # These are the expected outputs (query + param + info)
     evaluated_scores = evaluate(agent, guide, inputs, infos, num_samples=1, num_threads=1)
     expected_scores = [1, 0, 0, 0, 0]  # All inputs should match the expected outputs
-    assert evaluated_scores == expected_scores, f"Expected {expected_scores}, got {evaluated_scores}"   
+    assert (evaluated_scores == expected_scores).all(), f"Expected {expected_scores}, got {evaluated_scores}"   
+
+
+    evaluated_scores = evaluate(agent, guide, inputs, infos, num_samples=2, num_threads=1)
+    expected_scores = [[1, 1], [0, 0], [0, 0], [0, 0], [0, 0]]  # Each input should match the expected outputs twice
+    assert (evaluated_scores == expected_scores).all(), f"Expected {expected_scores}, got {evaluated_scores.tolist()}"

--- a/tests/unit_tests/test_modules.py
+++ b/tests/unit_tests/test_modules.py
@@ -400,3 +400,126 @@ def test_model_dump_and_import():
     finally:
         if os.path.exists(temp_file):
             os.remove(temp_file)
+
+def test_copy_function():
+    """Test the copy function of Module class."""
+    
+    @model
+    class TestCopyClass:
+        def __init__(self):
+            super().__init__()
+            self._param = node(10, trainable=True)
+            self.regular_attr = "original_value"
+            self.list_attr = [1, 2, 3]
+            self.dict_attr = {"key": "value"}
+        
+        @bundle(trainable=True)
+        def test_method(self, x):
+            return x + self._param
+        
+        def forward(self, x):
+            return self.test_method(x)
+    
+    # Create original instance
+    original = TestCopyClass()
+    original.regular_attr = "modified_value"
+    original.list_attr.append(4)
+    original.dict_attr["new_key"] = "new_value"
+    
+    # Create a copy
+    copied = original.copy()
+    
+    # Test that it's a different object
+    assert copied is not original
+    
+    # Test that regular attributes are copied (deep copy)
+    assert copied.regular_attr == "modified_value"
+    assert copied.list_attr == [1, 2, 3, 4]
+    assert copied.dict_attr == {"key": "value", "new_key": "new_value"}
+    
+    # Test that parameters are references to the original parameters
+    assert copied._param is original._param
+    assert copied.test_method.parameter is original.test_method.parameter
+    
+    # Test that modifying the original parameter affects the copy
+    original._param._data = 20
+    assert copied._param._data == 20
+    
+    # Test that modifying the copy's parameter affects the original
+    copied._param._data = 30
+    assert original._param._data == 30
+    
+    # Test that the copy can still function
+    result = copied.forward(5)
+    assert result._data == 35  # 5 + 30
+    
+    # Test that modifying regular attributes doesn't affect the original
+    copied.regular_attr = "copy_only_value"
+    assert original.regular_attr == "modified_value"
+    
+    # Test that modifying list/dict attributes doesn't affect the original (deep copy)
+    copied.list_attr.append(5)
+    assert len(original.list_attr) == 4
+    assert len(copied.list_attr) == 5
+    
+    copied.dict_attr["copy_only"] = "copy_value"
+    assert "copy_only" not in original.dict_attr
+    assert "copy_only" in copied.dict_attr
+
+def test_copy_function_with_nested_modules():
+    """Test the copy function with nested modules."""
+    
+    @model
+    class NestedModule:
+        def __init__(self):
+            super().__init__()
+            self._nested_param = node(5, trainable=True)
+        
+        @bundle(trainable=True)
+        def nested_method(self, x):
+            return x * self._nested_param
+        
+        def forward(self, x):
+            return self.nested_method(x)
+    
+    @model
+    class ParentModule:
+        def __init__(self):
+            super().__init__()
+            self._param = node(10, trainable=True)
+            self._nested = NestedModule()
+            self.regular_attr = "parent_value"
+        
+        @bundle(trainable=True)
+        def parent_method(self, x):
+            return self._nested.forward(x) + self._param
+        
+        def forward(self, x):
+            return self.parent_method(x)
+    
+    # Create original instance
+    original = ParentModule()
+    original.regular_attr = "modified_parent"
+    original._nested._nested_param._data = 7
+    
+    # Create a copy
+    copied = ParentModule()
+    copied = original.copy()
+    
+    # Test that it's a different object
+    assert copied is not original
+    
+    # Test that nested module is copied but parameters are references
+    assert copied._nested is not original._nested  # Different object
+    assert copied._nested._nested_param is original._nested._nested_param  # Same parameter reference
+    
+    # Test that regular attributes are copied
+    assert copied.regular_attr == "modified_parent"
+    
+    # Test that modifying nested parameter affects both
+    original._nested._nested_param._data = 8
+    assert copied._nested._nested_param._data == 8
+    
+    # Test that the copy can still function
+    result = copied.forward(3)
+    assert result._data == 34  # (3 * 8) + 10


### PR DESCRIPTION
NOTE: This is PR is based on PR #12. That needs to be merged first.

This PR adds a new method `batch_run` built on top of `async_run`, which handles copying needed for Module and AutoGuide (both classes are added with a new `copy` method). The algorithms' usage of `async_run` in forward is updated to use `batch_run` instead. `evaluate` now also accepts a new flag of `num_samples` for evaluating each input multiple times. This PR also fixes the typo bug in gsm8k example.

Feel free to suggest better names for `batch_run`. The current name is not very suitable as it is a decorator. 



