### PR TITLE
Add flags to set json keys in OptoPrime. Add DummyLLM for testing. Me…

### DIFF
--- a/opto/optimizers/optoprime.py
+++ b/opto/optimizers/optoprime.py
@@ -168,28 +168,49 @@ class OptoPrime(Optimizer):
     # Optimization
     default_objective = "You need to change the <value> of the variables in #Variables to improve the output in accordance to #Feedback."
 
-    output_format_prompt = dedent(
+    output_format_prompt_original = dedent(
         """
         Output_format: Your output should be in the following json format, satisfying the json syntax:
 
         {{
-        "reasoning": <Your reasoning>,
-        "answer": <Your answer>,
-        "suggestion": {{
+        "{reasoning}": <Your reasoning>,
+        "{answer}": <Your answer>,
+        "{suggestion}": {{
             <variable_1>: <suggested_value_1>,
             <variable_2>: <suggested_value_2>,
         }}
         }}
 
-        In "reasoning", explain the problem: 1. what the #Instruction means 2. what the #Feedback on #Output means to #Variables considering how #Variables are used in #Code and other values in #Documentation, #Inputs, #Others. 3. Reasoning about the suggested changes in #Variables (if needed) and the expected result.
+        In "{reasoning}", explain the problem: 1. what the #Instruction means 2. what the #Feedback on #Output means to #Variables considering how #Variables are used in #Code and other values in #Documentation, #Inputs, #Others. 3. Reasoning about the suggested changes in #Variables (if needed) and the expected result.
 
-        If #Instruction asks for an answer, write it down in "answer".
+        If #Instruction asks for an answer, write it down in "{answer}".
 
-        If you need to suggest a change in the values of #Variables, write down the suggested values in "suggestion". Remember you can change only the values in #Variables, not others. When <type> of a variable is (code), you should write the new definition in the format of python code without syntax errors, and you should not change the function name or the function signature.
+        If you need to suggest a change in the values of #Variables, write down the suggested values in "{suggestion}". Remember you can change only the values in #Variables, not others. When <type> of a variable is (code), you should write the new definition in the format of python code without syntax errors, and you should not change the function name or the function signature.
 
         If no changes or answer are needed, just output TERMINATE.
         """
     )
+
+    output_format_prompt_no_answer = dedent(
+        """
+        Output_format: Your output should be in the following json format, satisfying the json syntax:
+
+        {{
+        "{reasoning}": <Your reasoning>,
+        "{suggestion}": {{
+            <variable_1>: <suggested_value_1>,
+            <variable_2>: <suggested_value_2>,
+        }}
+        }}
+
+        In "{reasoning}", explain the problem: 1. what the #Instruction means 2. what the #Feedback on #Output means to #Variables considering how #Variables are used in #Code and other values in #Documentation, #Inputs, #Others. 3. Reasoning about the suggested changes in #Variables (if needed) and the expected result.
+
+        If you need to suggest a change in the values of #Variables, write down the suggested values in "{suggestion}". Remember you can change only the values in #Variables, not others. When <type> of a variable is (code), you should write the new definition in the format of python code without syntax errors, and you should not change the function name or the function signature.
+
+        If no changes are needed, just output TERMINATE.
+        """
+    )
+
 
     example_problem_template = dedent(
         """
@@ -234,6 +255,14 @@ class OptoPrime(Optimizer):
         """
     )
 
+    final_prompt_with_variables = dedent(
+        """
+        What are your suggestions on variables {names}?
+        
+        Your response:
+        """
+    )
+
     default_prompt_symbols = {
         "variables": "#Variables",
         "constraints": "#Constraints",
@@ -244,6 +273,12 @@ class OptoPrime(Optimizer):
         "instruction": "#Instruction",
         "code": "#Code",
         "documentation": "#Documentation",
+    }
+
+    default_json_keys = {
+        "reasoning": "reasoning",
+        "answer": "answer",
+        "suggestion": "suggestion",
     }
 
     def __init__(
@@ -259,7 +294,9 @@ class OptoPrime(Optimizer):
         max_tokens=4096,
         log=True,
         prompt_symbols=None,
+        json_keys=None,  # keys to use in the json object format (can remove "answer" if not needed)
         use_json_object_format=True,  # whether to use json object format for the response when calling LLM
+        highlight_variables=False,  # whether to highlight the variables at the end in the prompt
         **kwargs,
     ):
         super().__init__(parameters, *args, propagator=propagator, **kwargs)
@@ -295,7 +332,17 @@ class OptoPrime(Optimizer):
         self.prompt_symbols = copy.deepcopy(self.default_prompt_symbols)
         if prompt_symbols is not None:
             self.prompt_symbols.update(prompt_symbols)
+        if json_keys is not None:
+            self.default_json_keys.update(json_keys)        
+        if self.default_json_keys['answer'] is None:  # answer field is not needed 
+            del self.default_json_keys['answer']
+        if 'answer' not in self.default_json_keys:
+            # If 'answer' is not in the json keys, we use the no-answer format
+            self.output_format_prompt = self.output_format_prompt_no_answer.format(**self.default_json_keys)
+        else:  # If 'answer' is in the json keys, we use the original format of OptoPrime        
+            self.output_format_prompt = self.output_format_prompt_original.format(**self.default_json_keys)
         self.use_json_object_format = use_json_object_format
+        self.highlight_variables = highlight_variables
 
     def default_propagator(self):
         """Return the default Propagator object of the optimizer."""
@@ -403,7 +450,17 @@ class OptoPrime(Optimizer):
                 )
                 + user_prompt
             )
-        user_prompt += self.final_prompt
+        
+        
+        if self.highlight_variables:
+            var_names = []
+            for k, v in summary.variables.items():
+                var_names.append(f"{k}")  # ({type(v[0]).__name__})
+            var_names = ", ".join(var_names)
+
+            user_prompt += self.final_prompt_with_variables.format(names=var_names)
+        else:  # This is the original OptoPrime prompt
+            user_prompt += self.final_prompt
 
         # Add examples
         if len(self.memory) > 0:
@@ -494,11 +551,13 @@ class OptoPrime(Optimizer):
 
     def extract_llm_suggestion(self, response: str):
         """Extract the suggestion from the response."""
+        suggestion_tag = self.default_json_keys["suggestion"]
+
         suggestion = {}
         attempt_n = 0
         while attempt_n < 2:
             try:
-                suggestion = json.loads(response)["suggestion"]
+                suggestion = json.loads(response)[suggestion_tag]
                 break
             except json.JSONDecodeError:
                 # Remove things outside the brackets
@@ -514,7 +573,7 @@ class OptoPrime(Optimizer):
 
         if len(suggestion) == 0:
             # we try to extract key/value separately and return it as a dictionary
-            pattern = r'"suggestion"\s*:\s*\{(.*?)\}'
+            pattern = rf'"{suggestion_tag}"\s*:\s*\{{(.*?)\}}'
             suggestion_match = re.search(pattern, str(response), re.DOTALL)
             if suggestion_match:
                 suggestion = {}
@@ -530,7 +589,7 @@ class OptoPrime(Optimizer):
 
         if len(suggestion) == 0:
             if not self.ignore_extraction_error:
-                print("Cannot extract suggestion from LLM's response:")
+                print(f"Cannot extract {self.default_json_keys['suggestion']} from LLM's response:")
                 print(response)
 
         # if the suggested value is a code, and the entire code body is empty (i.e., not even function signature is present)

--- a/opto/utils/llm.py
+++ b/opto/utils/llm.py
@@ -313,6 +313,36 @@ class LLMFactory:
             return cls._profiles.get(profile)
         return cls._profiles
 
+
+class DummyLLM(AbstractModel):
+    """A dummy LLM that does nothing. Used for testing purposes."""
+    
+    def __init__(self, 
+                 callable,
+                 reset_freq: Union[int, None] = None) -> None:
+        # self.message = message
+        self.callable = callable
+        factory = lambda: self._factory()
+        super().__init__(factory, reset_freq)
+
+    def _factory(self):
+
+        # set response.choices[0].message.content
+        # create a fake container with above format
+
+        class Message: 
+            def __init__(self, content):
+                self.content = content
+        class Choice:
+            def __init__(self, content):
+                self.message = Message(content)
+        class Response:
+            def __init__(self, content):
+                self.choices = [Choice(content)]
+
+        return lambda *args, **kwargs:  Response(self.callable(*args, **kwargs))
+
+
 class LLM:
     """
     A unified entry point for all supported LLM backends.

--- a/tests/unit_tests/test_optoprime_update.py
+++ b/tests/unit_tests/test_optoprime_update.py
@@ -1,0 +1,54 @@
+from opto import trace
+from opto.optimizers import OptoPrime
+from opto.utils.llm import DummyLLM
+
+
+
+def test_json_keys():
+    """
+    Test that the OptoPrimeV2 class correctly initializes with json_keys.
+    """
+    param = trace.node(1, trainable=True)
+
+    def callable(messages,  **kwargs): 
+        format_prompt = """Output_format: Your output should be in the following json format, satisfying the json syntax:
+
+{
+"reasoning_mod": <Your reasoning>,
+"suggestion_mod": {
+    <variable_1>: <suggested_value_1>,
+    <variable_2>: <suggested_value_2>,
+}
+}
+
+In "reasoning_mod", explain the problem: 1. what the #Instruction means 2. what the #Feedback on #Output means to #Variables considering how #Variables are used in #Code and other values in #Documentation, #Inputs, #Others. 3. Reasoning about the suggested changes in #Variables (if needed) and the expected result.
+
+If you need to suggest a change in the values of #Variables, write down the suggested values in "suggestion_mod". Remember you can change only the values in #Variables, not others. When <type> of a variable is (code), you should write the new definition in the format of python code without syntax errors, and you should not change the function name or the function signature."""
+        assert format_prompt in messages[0]['content']  # system
+        assert '"answer":' not in messages[0]['content']
+        highlight_prompt = "What are your suggestions on variables int0?"
+        assert highlight_prompt in  messages[1]['content']  # user
+        return "Dummy response" #messages
+
+    llm = DummyLLM(callable)
+    
+    optimizer = OptoPrime(
+        parameters=[param], 
+        llm = llm,       
+        json_keys=dict(
+            reasoning="reasoning_mod",
+            answer=None,
+            suggestion="suggestion_mod"),
+        highlight_variables=True,
+    )
+    
+
+    y = param + 10 
+    optimizer.zero_feedback()
+    optimizer.backward(y, 'dummy feedback')
+    optimizer.step(verbose=True)
+
+
+
+
+


### PR DESCRIPTION
This PR adds some knobs to control the wording used in OptoPrime
As a by-product, it supports also removing the `answer` field in OptoPrime.
In addition, a `DummyLLM` class is added for testing purposes (This can be renamed.)

